### PR TITLE
test: use local zeebe-node

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,10 +56,11 @@ services:
       - LOG_LEVEL=debug
       - GRPC_VERBOSITY=DEBUG
       - GRPC_TRACE=channel,subchannel,call_stream
-    command: sh -c "ping test.test.localhost -c 1 && cd /usr/local/zeebe && npm install zeebe-node && node index.js"
+    command: sh -c "ping test.test.localhost -c 1 && cd /usr/local/zeebe && node index.js"
     volumes:
       - ./cert/rootCA.crt:/usr/local/zeebe/rootCA.crt
       - ./index.js:/usr/local/zeebe/index.js
+      - ./node_modules:/usr/local/zeebe/node_modules
     networks:
       - test
 


### PR DESCRIPTION
_JUST FOR TESTING._

This verifies that using the local (not yet broken) `zeebe-node` version handles SSL certificates and secure / insecure connection appropriately:

```sh
# install
npm ci

# prepare
npm run generate-certs

# test with security enabled
docker-compose up

# test with security disabled
docker-compose --env-file .env.insecure up 
```

In both tests you see `zeebe-node` and `zbctl` print the current cluster topology.
