### PR TITLE
Add @camunda8/sdk test + housekeeping

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ZEEBE_VERSION: ${{ matrix.zeebeVersion }}
+      NODE_VERSION: ${{ matrix.nodeVersion }}
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,6 +20,7 @@ jobs:
     env:
       ZEEBE_VERSION: ${{ matrix.zeebeVersion }}
       NODE_VERSION: ${{ matrix.nodeVersion }}
+      TEST_COUNT: 3
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -50,7 +51,7 @@ jobs:
       run: |
         npm run test:secure | tee output.txt
         results=$(grep "\"gatewayVersion\": \"${ZEEBE_VERSION}\"" -c output.txt)
-        if [[ "$results" != "2" ]]; then
+        if [[ "$results" != "$TEST_COUNT" ]]; then
           echo "missing <gatewayVersion>"
           exit 1
         fi
@@ -71,7 +72,7 @@ jobs:
       run: |
         npm run test:secure | tee output.txt
         results=$(grep "\"gatewayVersion\": \"${ZEEBE_VERSION}\"" -c output.txt)
-        if [[ "$results" != "2" ]]; then
+        if [[ "$results" != "$TEST_COUNT" ]]; then
           echo "missing <gatewayVersion>"
           exit 1
         fi
@@ -90,7 +91,7 @@ jobs:
       run: |
         npm run test:insecure | tee output.txt
         results=$(grep "\"gatewayVersion\": \"${ZEEBE_VERSION}\"" -c output.txt)
-        if [[ "$results" != "2" ]]; then
+        if [[ "$results" != "$TEST_COUNT" ]]; then
           echo "missing <gatewayVersion>"
           exit 1
         fi

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,16 +14,18 @@ jobs:
     strategy:
       matrix:
         zeebeVersion: [8.1.0, 8.2.2]
+        nodeVersion:
+        - 20
     runs-on: ubuntu-latest
     env:
       ZEEBE_VERSION: ${{ matrix.zeebeVersion }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
-    - name: Use Node.js 16
-      uses: actions/setup-node@v3
+      uses: actions/checkout@v4
+    - name: Use Node.js
+      uses: actions/setup-node@v4
       with:
-        node-version: 16
+        node-version: ${{ matrix.nodeVersion }}
         cache: 'npm'
     - name: Install dependencies
       run: npm ci

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -50,7 +50,7 @@ jobs:
         ZEEBE_ADDRESS: test.example.com:26500
       run: |
         npm run test:secure | tee output.txt
-        results=$(grep "\"gatewayVersion\": \"${ZEEBE_VERSION}\"" -c output.txt)
+        results=$(grep -E "\"gatewayVersion\":\s*\"${ZEEBE_VERSION}\"" -c output.txt)
         if [[ "$results" != "$TEST_COUNT" ]]; then
           echo "missing <gatewayVersion>"
           exit 1
@@ -71,7 +71,7 @@ jobs:
         ZEEBE_ADDRESS: test.example.com:443
       run: |
         npm run test:secure | tee output.txt
-        results=$(grep "\"gatewayVersion\": \"${ZEEBE_VERSION}\"" -c output.txt)
+        results=$(grep -E "\"gatewayVersion\":\s*\"${ZEEBE_VERSION}\"" -c output.txt)
         if [[ "$results" != "$TEST_COUNT" ]]; then
           echo "missing <gatewayVersion>"
           exit 1
@@ -90,7 +90,7 @@ jobs:
         ZEEBE_ADDRESS: test.example.com:26500
       run: |
         npm run test:insecure | tee output.txt
-        results=$(grep "\"gatewayVersion\": \"${ZEEBE_VERSION}\"" -c output.txt)
+        results=$(grep -E "\"gatewayVersion\":\s*\"${ZEEBE_VERSION}\"" -c output.txt)
         if [[ "$results" != "$TEST_COUNT" ]]; then
           echo "missing <gatewayVersion>"
           exit 1

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Generate a chain of trust, private keys and certificates for a particular `COMMO
 | `COMMON_NAME` | Common name used in the generated server (wildcard) certificate. `ZEEBE_HOSTNAME`, the servers publicly visible host name must be a sub-domain of this common name matching `*.COMMON_NAME` (one level deep). |
 
 #### Script
- 
+
 ```sh
 # generate root certificate and server cert + private key into ./cert
 #
@@ -76,7 +76,7 @@ In this test we securely connect our client to a Zeebe instance via TLS. We vali
 
 #### Script
 
-If successful you should see `zeebe-node` and `zbctl` print the current cluster topology.
+If successful you should see `zeebe-node`, `zbctl`, and `@camunda8/sdk` print the current cluster topology.
 
 ```sh
 # (once) ensure the configured hostname resolves to 127.0.0.1
@@ -171,7 +171,7 @@ ZEEBE_ADDRESS=sub.example.com:26500 npm run test:insecure
 
 #### Script
 
-If successful you should see `zeebe-node` and `zbctl` print the current cluster topology.
+If successful you should see `zeebe-node`, `zbctl`, and `@camunda8/sdk` print the current cluster topology.
 
 ```sh
 # test with security enabled
@@ -187,7 +187,7 @@ ZEEBE_HOSTNAME=sub.example.com docker compose --env-file .env.insecure up
 Assert the correct output, i.e. by verifying correct cluster topology logs:
 
 ```sh
-# the gateway version is produced twice as we test against `zebee-node` and `zbctl` 
+# the gateway version is produced twice as we test against `zebee-node` and `zbctl`
 [ "$(npm run test:secure | grep '"gatewayVersion": "8.1.0"' -c)" = 2 ] || echo "error: missing output <gatewayVersion>"
 ```
 

--- a/camunda-sdk.js
+++ b/camunda-sdk.js
@@ -1,0 +1,49 @@
+const { Camunda8 } = require('@camunda8/sdk');
+
+process.on('uncaughtException', error => {
+	console.error('uncaughtException', error);
+});
+
+
+async function run() {
+
+	const useTLS = process.env.ZEEBE_INSECURE_CONNECTION === 'false';
+	const address = process.env.ZEEBE_ADDRESS || 'localhost:26500';
+
+	const certsPath = process.env.ZEEBE_CA_CERTIFICATE_PATH;
+	const loglevel = process.env.LOG_LEVEL || 'info';
+
+	console.log(`
+		executing @camunda8/sdk with config:
+
+			ZEEBE_ADDRESS                 = ${address}
+			CAMUNDA_SECURE_CONNECTION     = ${useTLS}
+			CAMUNDA_CUSTOM_ROOT_CERT_PATH = ${certsPath}
+			ZEEBE_CLIENT_LOG_LEVEL        = ${loglevel}
+	`);
+
+	const c8 = new Camunda8({
+		ZEEBE_ADDRESS: address,
+		CAMUNDA_SECURE_CONNECTION: useTLS,
+		CAMUNDA_CUSTOM_ROOT_CERT_PATH: certsPath,
+		ZEEBE_CLIENT_LOG_LEVEL: loglevel,
+		ZEEBE_GRPC_CLIENT_RETRY: false,
+		CAMUNDA_OAUTH_DISABLED: true
+	});
+
+	const client = c8.getZeebeGrpcApiClient();
+
+	console.debug('pre-topology');
+
+	const topology = await client.topology();
+
+	console.debug('post-topology');
+
+	console.log(JSON.stringify(topology, null, 2))
+}
+
+run().catch(err => {
+	console.error('error', err);
+
+	process.exit(1);
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
   zbctl-test:
     links:
       - "zeebe:${ZEEBE_HOSTNAME:-sub.example.com}"
-    image: node:16-alpine
+    image: "node:${NODE_VERSION:-20}-alpine"
     depends_on:
       zeebe:
         condition: service_healthy
@@ -64,7 +64,7 @@ services:
   zebee-node-test:
     links:
       - "zeebe:${ZEEBE_HOSTNAME:-sub.example.com}"
-    image: node:16-alpine
+    image: "node:${NODE_VERSION:-20}-alpine"
     depends_on:
       zeebe:
         condition: service_healthy
@@ -85,7 +85,7 @@ services:
   camunda-sdk-test:
     links:
       - "zeebe:${ZEEBE_HOSTNAME:-sub.example.com}"
-    image: node:16-alpine
+    image: "node:${NODE_VERSION:-20}-alpine"
     depends_on:
       zeebe:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "2"
 services:
   zeebe:
     container_name: zeebe_broker
-    image: camunda/zeebe:${ZEEBE_VERSION:-8.2.0}
+    image: camunda/zeebe:${ZEEBE_VERSION:-8.5.1}
     environment:
       - ZEEBE_LOG_LEVEL=debug
       - ZEEBE_BROKER_NETWORK_HOST=0.0.0.0
@@ -79,6 +79,27 @@ services:
     volumes:
       - ./cert/root.crt:/usr/local/zeebe/root.crt
       - ./index.js:/usr/local/zeebe/index.js
+      - ./node_modules:/usr/local/zeebe/node_modules
+    networks:
+      - test
+  camunda-sdk-test:
+    links:
+      - "zeebe:${ZEEBE_HOSTNAME:-sub.example.com}"
+    image: node:16-alpine
+    depends_on:
+      zeebe:
+        condition: service_healthy
+    environment:
+      - ZEEBE_ADDRESS=${ZEEBE_HOSTNAME:-sub.example.com}:${ZEEBE_PORT:-26500}
+      - ZEEBE_INSECURE_CONNECTION=${ZEEBE_INSECURE_CONNECTION:-false}
+      - ZEEBE_CA_CERTIFICATE_PATH=/usr/local/zeebe/root.crt
+      - LOG_LEVEL=debug
+      - GRPC_VERBOSITY=DEBUG
+      - GRPC_TRACE=channel,subchannel,call_stream
+    command: sh -c "ping ${ZEEBE_HOSTNAME:-sub.example.com} -c 1 && cd /usr/local/zeebe && node camunda-sdk.js"
+    volumes:
+      - ./cert/root.crt:/usr/local/zeebe/root.crt
+      - ./camunda-sdk.js:/usr/local/zeebe/camunda-sdk.js
       - ./node_modules:/usr/local/zeebe/node_modules
     networks:
       - test

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@camunda8/sdk": "^8.5.3",
         "zbctl": "^8.2.6",
         "zeebe-node": "^8.2.5"
       },
@@ -17,6 +18,127 @@
       },
       "optionalDependencies": {
         "vscode-windows-ca-certs": "^0.3.0"
+      }
+    },
+    "node_modules/@camunda8/sdk": {
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/@camunda8/sdk/-/sdk-8.5.3.tgz",
+      "integrity": "sha512-nJatfx5VjtqwpAMwKppjP5Mvyf87YAfrUCM2c1dnzzo1TPylGHxUZlJoOK9eCbcRh+re+5Us2tpezdHR9bdnKw==",
+      "dependencies": {
+        "@grpc/grpc-js": "1.10.7",
+        "@grpc/proto-loader": "0.7.13",
+        "chalk": "^2.4.2",
+        "console-stamp": "^3.0.2",
+        "dayjs": "^1.8.15",
+        "debug": "^4.3.4",
+        "fast-xml-parser": "^4.1.3",
+        "got": "^11.8.6",
+        "jwt-decode": "^4.0.0",
+        "lodash.mergewith": "^4.6.2",
+        "long": "^4.0.0",
+        "lossless-json": "^4.0.1",
+        "neon-env": "^0.1.3",
+        "promise-retry": "^1.1.1",
+        "reflect-metadata": "^0.2.1",
+        "stack-trace": "0.0.10",
+        "typed-duration": "^1.0.12",
+        "uuid": "^7.0.3"
+      },
+      "optionalDependencies": {
+        "win-ca": "3.5.1"
+      }
+    },
+    "node_modules/@camunda8/sdk/node_modules/@grpc/grpc-js": {
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.10.7.tgz",
+      "integrity": "sha512-ZMBVjSeDAz3tFSehyO6Pd08xZT1HfIwq3opbeM4cDlBh52gmwp0wVIPcQur53NN0ac68HMZ/7SF2rGRD5KmVmg==",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.7.13",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@camunda8/sdk/node_modules/@grpc/proto-loader": {
+      "version": "0.7.13",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.13.tgz",
+      "integrity": "sha512-AiXO/bfe9bmxBjxxtYxFAXGZvMaN5s8kO+jBHAJCON8rJoB5YS/D6X7ZNc6XQkuHNmyl4CYaMI1fJ/Gn27RGGw==",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@camunda8/sdk/node_modules/@grpc/proto-loader/node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+    },
+    "node_modules/@camunda8/sdk/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@camunda8/sdk/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@camunda8/sdk/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/@camunda8/sdk/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@camunda8/sdk/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@grpc/grpc-js": {
@@ -47,6 +169,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -678,6 +809,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-electron": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
+      "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==",
+      "optional": true
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -721,6 +858,14 @@
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
     },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.2.tgz",
@@ -734,10 +879,20 @@
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
     },
+    "node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
+    },
     "node_modules/long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    },
+    "node_modules/lossless-json": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lossless-json/-/lossless-json-4.0.1.tgz",
+      "integrity": "sha512-l0L+ppmgPDnb+JGxNLndPtJZGNf6+ZmVaQzoxQm3u6TXmhdnsA+YtdVR8DjzZd/em58686CQhOFDPewfJ4l7MA=="
     },
     "node_modules/lowercase-keys": {
       "version": "2.0.0",
@@ -757,6 +912,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+      "optional": true,
+      "dependencies": {
+        "pify": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/mimic-response": {
@@ -793,11 +960,28 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
+    "node_modules/neon-env": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/neon-env/-/neon-env-0.1.3.tgz",
+      "integrity": "sha512-Zo+L6Nm19gJrjyfhxn/ZDm8eIIDzr75o64ZhijBau4LNuhLzjEAteRg3gchIvgaN8XTo5BxN6iTNP5clZQ0agA==",
+      "engines": {
+        "node": "^14.18 || >=16.0.0"
+      }
+    },
     "node_modules/node-addon-api": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
       "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
       "optional": true
+    },
+    "node_modules/node-forge": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "optional": true,
+      "engines": {
+        "node": ">= 6.13.0"
+      }
     },
     "node_modules/nodemon": {
       "version": "3.0.1",
@@ -890,6 +1074,15 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+      "optional": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/promise-retry": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
@@ -903,9 +1096,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.4.tgz",
-      "integrity": "sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.3.0.tgz",
+      "integrity": "sha512-YWD03n3shzV9ImZRX3ccbjqLxj7NokGN0V/ESiBV5xWqrommYHYiihuIyavq03pWSGqlyvYUFmfoMKd+1rPA/g==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -981,6 +1174,11 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="
     },
     "node_modules/registry-auth-token": {
       "version": "3.3.2",
@@ -1080,6 +1278,18 @@
         "node": ">=10"
       }
     },
+    "node_modules/split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "optional": true,
+      "dependencies": {
+        "through": "2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/stack-trace": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
@@ -1135,6 +1345,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "optional": true
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -1199,6 +1415,19 @@
       ],
       "dependencies": {
         "node-addon-api": "^3.0.2"
+      }
+    },
+    "node_modules/win-ca": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/win-ca/-/win-ca-3.5.1.tgz",
+      "integrity": "sha512-RNy9gpBS6cxWHjfbqwBA7odaHyT+YQNhtdpJZwYCFoxB/Dq22oeOZ9YCXMwjhLytKpo7JJMnKdJ/ve7N12zzfQ==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "is-electron": "^2.2.0",
+        "make-dir": "^1.3.0",
+        "node-forge": "^1.2.1",
+        "split": "^1.0.1"
       }
     },
     "node_modules/wrap-ansi": {
@@ -1356,6 +1585,103 @@
     }
   },
   "dependencies": {
+    "@camunda8/sdk": {
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/@camunda8/sdk/-/sdk-8.5.3.tgz",
+      "integrity": "sha512-nJatfx5VjtqwpAMwKppjP5Mvyf87YAfrUCM2c1dnzzo1TPylGHxUZlJoOK9eCbcRh+re+5Us2tpezdHR9bdnKw==",
+      "requires": {
+        "@grpc/grpc-js": "1.10.7",
+        "@grpc/proto-loader": "0.7.13",
+        "chalk": "^2.4.2",
+        "console-stamp": "^3.0.2",
+        "dayjs": "^1.8.15",
+        "debug": "^4.3.4",
+        "fast-xml-parser": "^4.1.3",
+        "got": "^11.8.6",
+        "jwt-decode": "^4.0.0",
+        "lodash.mergewith": "^4.6.2",
+        "long": "^4.0.0",
+        "lossless-json": "^4.0.1",
+        "neon-env": "^0.1.3",
+        "promise-retry": "^1.1.1",
+        "reflect-metadata": "^0.2.1",
+        "stack-trace": "0.0.10",
+        "typed-duration": "^1.0.12",
+        "uuid": "^7.0.3",
+        "win-ca": "3.5.1"
+      },
+      "dependencies": {
+        "@grpc/grpc-js": {
+          "version": "1.10.7",
+          "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.10.7.tgz",
+          "integrity": "sha512-ZMBVjSeDAz3tFSehyO6Pd08xZT1HfIwq3opbeM4cDlBh52gmwp0wVIPcQur53NN0ac68HMZ/7SF2rGRD5KmVmg==",
+          "requires": {
+            "@grpc/proto-loader": "^0.7.13",
+            "@js-sdsl/ordered-map": "^4.4.2"
+          }
+        },
+        "@grpc/proto-loader": {
+          "version": "0.7.13",
+          "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.13.tgz",
+          "integrity": "sha512-AiXO/bfe9bmxBjxxtYxFAXGZvMaN5s8kO+jBHAJCON8rJoB5YS/D6X7ZNc6XQkuHNmyl4CYaMI1fJ/Gn27RGGw==",
+          "requires": {
+            "lodash.camelcase": "^4.3.0",
+            "long": "^5.0.0",
+            "protobufjs": "^7.2.5",
+            "yargs": "^17.7.2"
+          },
+          "dependencies": {
+            "long": {
+              "version": "5.2.3",
+              "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+              "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+            }
+          }
+        },
+        "cliui": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.1",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "yargs": {
+          "version": "17.7.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+          "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+          "requires": {
+            "cliui": "^8.0.1",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.3",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^21.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "21.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
+        }
+      }
+    },
     "@grpc/grpc-js": {
       "version": "1.8.7",
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.7.tgz",
@@ -1376,6 +1702,11 @@
         "protobufjs": "^7.0.0",
         "yargs": "^16.2.0"
       }
+    },
+    "@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw=="
     },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -1862,6 +2193,12 @@
         "binary-extensions": "^2.0.0"
       }
     },
+    "is-electron": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
+      "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==",
+      "optional": true
+    },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -1893,6 +2230,11 @@
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
     },
+    "jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA=="
+    },
     "keyv": {
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.2.tgz",
@@ -1906,10 +2248,20 @@
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
     },
+    "lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
+    },
     "long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    },
+    "lossless-json": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lossless-json/-/lossless-json-4.0.1.tgz",
+      "integrity": "sha512-l0L+ppmgPDnb+JGxNLndPtJZGNf6+ZmVaQzoxQm3u6TXmhdnsA+YtdVR8DjzZd/em58686CQhOFDPewfJ4l7MA=="
     },
     "lowercase-keys": {
       "version": "2.0.0",
@@ -1923,6 +2275,15 @@
       "dev": true,
       "requires": {
         "yallist": "^4.0.0"
+      }
+    },
+    "make-dir": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+      "optional": true,
+      "requires": {
+        "pify": "^3.0.0"
       }
     },
     "mimic-response": {
@@ -1950,10 +2311,21 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
+    "neon-env": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/neon-env/-/neon-env-0.1.3.tgz",
+      "integrity": "sha512-Zo+L6Nm19gJrjyfhxn/ZDm8eIIDzr75o64ZhijBau4LNuhLzjEAteRg3gchIvgaN8XTo5BxN6iTNP5clZQ0agA=="
+    },
     "node-addon-api": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
       "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
+      "optional": true
+    },
+    "node-forge": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
       "optional": true
     },
     "nodemon": {
@@ -2013,6 +2385,12 @@
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true
     },
+    "pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+      "optional": true
+    },
     "promise-retry": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
@@ -2023,9 +2401,9 @@
       }
     },
     "protobufjs": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.4.tgz",
-      "integrity": "sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.3.0.tgz",
+      "integrity": "sha512-YWD03n3shzV9ImZRX3ccbjqLxj7NokGN0V/ESiBV5xWqrommYHYiihuIyavq03pWSGqlyvYUFmfoMKd+1rPA/g==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -2087,6 +2465,11 @@
       "requires": {
         "picomatch": "^2.2.1"
       }
+    },
+    "reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="
     },
     "registry-auth-token": {
       "version": "3.3.2",
@@ -2151,6 +2534,15 @@
         "semver": "^7.5.3"
       }
     },
+    "split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "optional": true,
+      "requires": {
+        "through": "2"
+      }
+    },
     "stack-trace": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
@@ -2191,6 +2583,12 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "optional": true
     },
     "to-regex-range": {
       "version": "5.0.1",
@@ -2242,6 +2640,18 @@
       "optional": true,
       "requires": {
         "node-addon-api": "^3.0.2"
+      }
+    },
+    "win-ca": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/win-ca/-/win-ca-3.5.1.tgz",
+      "integrity": "sha512-RNy9gpBS6cxWHjfbqwBA7odaHyT+YQNhtdpJZwYCFoxB/Dq22oeOZ9YCXMwjhLytKpo7JJMnKdJ/ve7N12zzfQ==",
+      "optional": true,
+      "requires": {
+        "is-electron": "^2.2.0",
+        "make-dir": "^1.3.0",
+        "node-forge": "^1.2.1",
+        "split": "^1.0.1"
       }
     },
     "wrap-ansi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@camunda8/sdk": "^8.5.3",
-        "zbctl": "^8.2.6",
-        "zeebe-node": "^8.2.5"
+        "zbctl": "^8.4.1",
+        "zeebe-node": "^8.3.2"
       },
       "devDependencies": {
         "nodemon": "^3.0.1"
@@ -82,19 +82,6 @@
       "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
       "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
-    "node_modules/@camunda8/sdk/node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@camunda8/sdk/node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -116,37 +103,12 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
-    "node_modules/@camunda8/sdk/node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@camunda8/sdk/node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.8.7",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.7.tgz",
-      "integrity": "sha512-dRAWjRFN1Zy9mzPNLkFFIWT8T6C9euwluzCHZUKuhC+Bk3MayNPcpgDRyG+sg+n2sitEUySKxUynirVpu9ItKw==",
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.7.tgz",
+      "integrity": "sha512-yMaA/cIsRhGzW3ymCNpdlPcInXcovztlgu/rirThj2b87u3RzWUszliOqZ/pldy7yhmJPS8uwog+kZSTa4A0PQ==",
       "dependencies": {
-        "@grpc/proto-loader": "^0.7.0",
+        "@grpc/proto-loader": "^0.7.8",
         "@types/node": ">=12.12.47"
       },
       "engines": {
@@ -154,15 +116,14 @@
       }
     },
     "node_modules/@grpc/proto-loader": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.4.tgz",
-      "integrity": "sha512-MnWjkGwqQ3W8fx94/c1CwqLsNmHHv2t0CFn+9++6+cDphC1lolpg9M2OU0iebIjK//pBNX9e94ho+gjx6vz39w==",
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.10.tgz",
+      "integrity": "sha512-CAqDfoaQ8ykFd9zqBDn4k6iWT9loLAlc2ETmDFS9JCD70gDcnA4L3AFEo2iV7KyAtAAHFW9ftq1Fz+Vsgq80RQ==",
       "dependencies": {
-        "@types/long": "^4.0.1",
         "lodash.camelcase": "^4.3.0",
-        "long": "^4.0.0",
-        "protobufjs": "^7.0.0",
-        "yargs": "^16.2.0"
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.4",
+        "yargs": "^17.7.2"
       },
       "bin": {
         "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
@@ -170,6 +131,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
     "node_modules/@js-sdsl/ordered-map": {
       "version": "4.4.2",
@@ -279,11 +245,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/long": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
-      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
     },
     "node_modules/@types/node": {
       "version": "18.11.18",
@@ -439,13 +400,16 @@
       }
     },
     "node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dependencies": {
         "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
+        "strip-ansi": "^6.0.1",
         "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/clone-response": {
@@ -1496,34 +1460,34 @@
       "dev": true
     },
     "node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dependencies": {
-        "cliui": "^7.0.2",
+        "cliui": "^8.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
+        "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
+        "yargs-parser": "^21.1.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/zbctl": {
-      "version": "8.2.6",
-      "resolved": "https://registry.npmjs.org/zbctl/-/zbctl-8.2.6.tgz",
-      "integrity": "sha512-gZZQew1VZo8WTfxPxqyLha+gIkKaJQK2bmO1/a9mirF/G2AEw/dBdVAPME2YL8jc/p/tiqi/7q50L+GVjrqMiA==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/zbctl/-/zbctl-8.4.1.tgz",
+      "integrity": "sha512-FkNGeTh3AxgWDIKdMraRjop9lzkzYL+Q7FEGnwna5wMOynLcMJcb93PU0WGuvRsy52XlKlwqgEkzplWBOZvw2A==",
       "dependencies": {
         "chalk": "^2.4.2",
         "update-check": "^1.5.3"
@@ -1536,12 +1500,13 @@
       }
     },
     "node_modules/zeebe-node": {
-      "version": "8.2.5",
-      "resolved": "https://registry.npmjs.org/zeebe-node/-/zeebe-node-8.2.5.tgz",
-      "integrity": "sha512-QhEnnchsuM7j0v8cCtOKMPfV/MdtJm8o/NY2abKyB45X6oNOUJGKuTCpt5WFiPjHdmD+VWUXfEm6ATl1OZevGQ==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/zeebe-node/-/zeebe-node-8.3.2.tgz",
+      "integrity": "sha512-3/xbiTvhaa668JHtMEwELv5dN6HR7Qw8gzmCdjp3Brj6ekdhROVx8x/0JWKSV3Mx64ac3+eEc+9nB5+ZXcO/bg==",
+      "deprecated": "This package is deprecated. Please use the official SDK package @camunda8/sdk. See: https://github.com/camunda/camunda-8-js-sdk",
       "dependencies": {
-        "@grpc/grpc-js": "1.8.7",
-        "@grpc/proto-loader": "0.7.4",
+        "@grpc/grpc-js": "1.9.7",
+        "@grpc/proto-loader": "0.7.10",
         "chalk": "^2.4.2",
         "console-stamp": "^3.0.2",
         "dayjs": "^1.8.15",
@@ -1638,16 +1603,6 @@
             }
           }
         },
-        "cliui": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-          "requires": {
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.1",
-            "wrap-ansi": "^7.0.0"
-          }
-        },
         "debug": {
           "version": "4.3.4",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -1660,47 +1615,34 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "yargs": {
-          "version": "17.7.2",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-          "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-          "requires": {
-            "cliui": "^8.0.1",
-            "escalade": "^3.1.1",
-            "get-caller-file": "^2.0.5",
-            "require-directory": "^2.1.1",
-            "string-width": "^4.2.3",
-            "y18n": "^5.0.5",
-            "yargs-parser": "^21.1.1"
-          }
-        },
-        "yargs-parser": {
-          "version": "21.1.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
         }
       }
     },
     "@grpc/grpc-js": {
-      "version": "1.8.7",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.7.tgz",
-      "integrity": "sha512-dRAWjRFN1Zy9mzPNLkFFIWT8T6C9euwluzCHZUKuhC+Bk3MayNPcpgDRyG+sg+n2sitEUySKxUynirVpu9ItKw==",
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.7.tgz",
+      "integrity": "sha512-yMaA/cIsRhGzW3ymCNpdlPcInXcovztlgu/rirThj2b87u3RzWUszliOqZ/pldy7yhmJPS8uwog+kZSTa4A0PQ==",
       "requires": {
-        "@grpc/proto-loader": "^0.7.0",
+        "@grpc/proto-loader": "^0.7.8",
         "@types/node": ">=12.12.47"
       }
     },
     "@grpc/proto-loader": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.4.tgz",
-      "integrity": "sha512-MnWjkGwqQ3W8fx94/c1CwqLsNmHHv2t0CFn+9++6+cDphC1lolpg9M2OU0iebIjK//pBNX9e94ho+gjx6vz39w==",
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.10.tgz",
+      "integrity": "sha512-CAqDfoaQ8ykFd9zqBDn4k6iWT9loLAlc2ETmDFS9JCD70gDcnA4L3AFEo2iV7KyAtAAHFW9ftq1Fz+Vsgq80RQ==",
       "requires": {
-        "@types/long": "^4.0.1",
         "lodash.camelcase": "^4.3.0",
-        "long": "^4.0.0",
-        "protobufjs": "^7.0.0",
-        "yargs": "^16.2.0"
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.4",
+        "yargs": "^17.7.2"
+      },
+      "dependencies": {
+        "long": {
+          "version": "5.2.3",
+          "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+          "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+        }
       }
     },
     "@js-sdsl/ordered-map": {
@@ -1798,11 +1740,6 @@
       "requires": {
         "@types/node": "*"
       }
-    },
-    "@types/long": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
-      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
     },
     "@types/node": {
       "version": "18.11.18",
@@ -1923,12 +1860,12 @@
       }
     },
     "cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "requires": {
         "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
+        "strip-ansi": "^6.0.1",
         "wrap-ansi": "^7.0.0"
       }
     },
@@ -2704,40 +2641,40 @@
       "dev": true
     },
     "yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "requires": {
-        "cliui": "^7.0.2",
+        "cliui": "^8.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
+        "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
+        "yargs-parser": "^21.1.1"
       }
     },
     "yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
     },
     "zbctl": {
-      "version": "8.2.6",
-      "resolved": "https://registry.npmjs.org/zbctl/-/zbctl-8.2.6.tgz",
-      "integrity": "sha512-gZZQew1VZo8WTfxPxqyLha+gIkKaJQK2bmO1/a9mirF/G2AEw/dBdVAPME2YL8jc/p/tiqi/7q50L+GVjrqMiA==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/zbctl/-/zbctl-8.4.1.tgz",
+      "integrity": "sha512-FkNGeTh3AxgWDIKdMraRjop9lzkzYL+Q7FEGnwna5wMOynLcMJcb93PU0WGuvRsy52XlKlwqgEkzplWBOZvw2A==",
       "requires": {
         "chalk": "^2.4.2",
         "update-check": "^1.5.3"
       }
     },
     "zeebe-node": {
-      "version": "8.2.5",
-      "resolved": "https://registry.npmjs.org/zeebe-node/-/zeebe-node-8.2.5.tgz",
-      "integrity": "sha512-QhEnnchsuM7j0v8cCtOKMPfV/MdtJm8o/NY2abKyB45X6oNOUJGKuTCpt5WFiPjHdmD+VWUXfEm6ATl1OZevGQ==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/zeebe-node/-/zeebe-node-8.3.2.tgz",
+      "integrity": "sha512-3/xbiTvhaa668JHtMEwELv5dN6HR7Qw8gzmCdjp3Brj6ekdhROVx8x/0JWKSV3Mx64ac3+eEc+9nB5+ZXcO/bg==",
       "requires": {
-        "@grpc/grpc-js": "1.8.7",
-        "@grpc/proto-loader": "0.7.4",
+        "@grpc/grpc-js": "1.9.7",
+        "@grpc/proto-loader": "0.7.10",
         "chalk": "^2.4.2",
         "console-stamp": "^3.0.2",
         "dayjs": "^1.8.15",

--- a/package.json
+++ b/package.json
@@ -7,15 +7,17 @@
     "test": "npm run test:insecure && npm run test:secure",
     "test:insecure": "ZEEBE_INSECURE_CONNECTION=true npm run test:clients",
     "test:secure": "ZEEBE_INSECURE_CONNECTION=false ZEEBE_CA_CERTIFICATE_PATH=./cert/root.crt npm run test:clients",
-    "test:clients": "npm run test:zeebe-node && npm run test:zbctl",
+    "test:clients": "npm run test:zeebe-node && npm run test:zbctl && npm run test:camunda-sdk",
     "test:zbctl": "zbctl status -o json",
     "test:zeebe-node": "LOG_LEVEL=debug GRPC_VERBOSITY=DEBUG GRPC_TRACE=channel,subchannel,call_stream node index.js",
+    "test:camunda-sdk": "LOG_LEVEL=debug GRPC_VERBOSITY=DEBUG GRPC_TRACE=channel,subchannel,call_stream node camunda-sdk.js",
     "generate-certs": "cd cert && ./setup.sh"
   },
   "keywords": [],
   "author": "Maciej Barelkowski <maciej.barelkowski@camunda.com>",
   "license": "MIT",
   "dependencies": {
+    "@camunda8/sdk": "^8.5.3",
     "zbctl": "^8.2.6",
     "zeebe-node": "^8.2.5"
   },

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   "license": "MIT",
   "dependencies": {
     "@camunda8/sdk": "^8.5.3",
-    "zbctl": "^8.2.6",
-    "zeebe-node": "^8.2.5"
+    "zbctl": "^8.4.1",
+    "zeebe-node": "^8.3.2"
   },
   "devDependencies": {
     "nodemon": "^3.0.1"


### PR DESCRIPTION
This PR adds @camunda8/sdk test, and also updates the CI to the latest supported versions of the actions and Node.
I also updated zeebe-node and zbctl deps.

Closes #13