### PR TITLE
Replicate usual intermediate CA setup in test environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ You can bring your own root certificate + server certificate / private key pair 
 
 ```sh
 # ./cert/root.cert.pem                - root certificate
+# ./cert/ca-chain.cert.pem            - root + intermediate certificate chain
 # ./cert/server.cert.pem              - server certificate
+# ./cert/server-fullchain.cert.pem    - server certificate + full chain
 # ./cert/server.key.pem               - server private key
 ```
 
@@ -92,7 +94,7 @@ ZEEBE_ADDRESS=sub.example.com:26500 npm run test:secure
 To test with the [Camunda Modeler](https://github.com/camunda/camunda-modeler) pass the custom SSL root certificate use the `--zeebe-ssl-certificate` flag:
 
 ```sh
-camunda-modeler --zeebe-ssl-certificate=cert/root.cert.pem
+camunda-modeler --zeebe-ssl-certificate=cert/ca-chain.cert.pem
 ```
 
 
@@ -129,7 +131,7 @@ ZEEBE_ADDRESS=sub.example.com:443 npm run test:secure
 To test with the [Camunda Modeler](https://github.com/camunda/camunda-modeler) pass the custom SSL root certificate use the `--zeebe-ssl-certificate` flag:
 
 ```sh
-camunda-modeler --zeebe-ssl-certificate=cert/root.cert.pem
+camunda-modeler --zeebe-ssl-certificate=cert/ca-chain.cert.pem
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ If successful you should see `zeebe-node` and `zbctl` print the current cluster 
 # (once) ensure the configured hostname resolves to 127.0.0.1
 ZEEBE_HOSTNAME=sub.example.com sh -c 'echo "127.0.0.1    $ZEEBE_HOSTNAME"' | sudo tee -a /etc/hosts
 
-# start zeebe with security enabled
+# start zeebe + proxy with security enabled
 ZEEBE_HOSTNAME=sub.example.com docker compose --env-file .env.proxy up zeebe proxy
 
 # test with security enabled
@@ -132,6 +132,25 @@ To test with the [Camunda Modeler](https://github.com/camunda/camunda-modeler) p
 
 ```sh
 camunda-modeler --zeebe-ssl-certificate=cert/ca-chain.cert.pem
+```
+
+> [!NOTE]
+> This setup assumes that intermediate and root certificates are installed
+> on the client's machine. An alternative setup is that the server provides
+> the [full certificate chain](https://www.rfc-editor.org/rfc/rfc5246#section-7.4.2), replicated below.
+
+```sh
+# start zeebe + proxy with security enabled
+PROXY_SERVER_CERTIFICATE=server-fullchain.cert.pem ZEEBE_HOSTNAME=sub.example.com docker compose --env-file .env.proxy up zeebe proxy
+
+# test with security enabled
+CA_CERTIFICATE=root.cert.pem ZEEBE_ADDRESS=sub.example.com:443 npm run test:secure
+```
+
+To test with the [Camunda Modeler](https://github.com/camunda/camunda-modeler) you now only have to pass the root certificate:
+
+```sh
+camunda-modeler --zeebe-ssl-certificate=cert/root.cert.pem
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ Use this package to perform various tests and test preparations:
 You can bring your own root certificate + server certificate / private key pair and store them in `./cert` in the following format:
 
 ```sh
-# ./cert/root.crt   - root certificate
-# ./cert/server.crt - server certificate
-# ./cert/server.key - server private key
+# ./cert/root.cert.pem                - root certificate
+# ./cert/server.cert.pem              - server certificate
+# ./cert/server.key.pem               - server private key
 ```
 
 Alternatively use the [contained script](#generate-certificates) to generate them for a particular `COMMON_NAME`.
@@ -92,7 +92,7 @@ ZEEBE_ADDRESS=sub.example.com:26500 npm run test:secure
 To test with the [Camunda Modeler](https://github.com/camunda/camunda-modeler) pass the custom SSL root certificate use the `--zeebe-ssl-certificate` flag:
 
 ```sh
-camunda-modeler --zeebe-ssl-certificate=cert/root.crt
+camunda-modeler --zeebe-ssl-certificate=cert/root.cert.pem
 ```
 
 
@@ -129,7 +129,7 @@ ZEEBE_ADDRESS=sub.example.com:443 npm run test:secure
 To test with the [Camunda Modeler](https://github.com/camunda/camunda-modeler) pass the custom SSL root certificate use the `--zeebe-ssl-certificate` flag:
 
 ```sh
-camunda-modeler --zeebe-ssl-certificate=cert/root.crt
+camunda-modeler --zeebe-ssl-certificate=cert/root.cert.pem
 ```
 
 

--- a/cert/setup.sh
+++ b/cert/setup.sh
@@ -12,12 +12,12 @@ openssl req -x509 \
             -nodes \
             -newkey rsa:4096 \
             -subj "/CN=$COMMON_NAME/C=US/L=San Fransisco" \
-            -keyout root.key -out root.crt
+            -keyout root.key.pem -out root.cert.pem
 
 # Generate Private key
 
-openssl genrsa -out server.key 4096
-openssl pkcs8 -topk8 -inform pem -in server.key -outform pem -nocrypt -out server.pem
+openssl genrsa -out server.key.pem 4096
+openssl pkcs8 -topk8 -inform pem -in server.key.pem -outform pem -nocrypt -out server.cert.pem
 
 # Create csf conf
 
@@ -47,7 +47,7 @@ EOF
 
 # create CSR request using private key
 
-openssl req -new -key server.pem -out server.csr -config server.csr.conf
+openssl req -new -key server.cert.pem -out server.csr -config server.csr.conf
 
 # Create a external config file for the certificate
 
@@ -67,7 +67,7 @@ EOF
 
 openssl x509 -req \
     -in server.csr \
-    -CA root.crt -CAkey root.key \
+    -CA root.cert.pem -CAkey root.key.pem \
     -CAcreateserial -out server.crt \
     -days 365 \
     -sha256 -extfile server.cert.conf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     image: nginx
     depends_on:
       zeebe:
-        condition: service_healthy
+        condition: service_started
     environment:
       - ZEEBE_PORT=${ZEEBE_PORT:-26500}
       - ZEEBE_HOSTNAME=${ZEEBE_HOSTNAME:-sub.example.com}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,10 +36,12 @@ services:
     environment:
       - ZEEBE_PORT=${ZEEBE_PORT:-26500}
       - ZEEBE_HOSTNAME=${ZEEBE_HOSTNAME:-sub.example.com}
+      - PROXY_SERVER_CERTIFICATE=${PROXY_SERVER_CERTIFICATE:-server.cert.pem}
       - PROXY_PORT=${PROXY_PORT:-443}
     volumes:
       - ./nginx/templates:/etc/nginx/templates
       - ./cert/server.cert.pem:/usr/local/proxy/server.cert.pem
+      - ./cert/server-fullchain.cert.pem:/usr/local/proxy/server-fullchain.cert.pem
       - ./cert/server.key.pem:/usr/local/proxy/server.key.pem
     ports:
       - "${PROXY_PORT:-443}:${PROXY_PORT:-443}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "2"
-
 services:
   zeebe:
     container_name: zeebe_broker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,13 +8,13 @@ services:
       - ZEEBE_LOG_LEVEL=debug
       - ZEEBE_BROKER_NETWORK_HOST=0.0.0.0
       - ZEEBE_BROKER_GATEWAY_SECURITY_ENABLED=${ZEEBE_BROKER_GATEWAY_SECURITY_ENABLED:-true}
-      - ZEEBE_BROKER_GATEWAY_SECURITY_CERTIFICATECHAINPATH=/usr/local/zeebe/server.crt
-      - ZEEBE_BROKER_GATEWAY_SECURITY_PRIVATEKEYPATH=/usr/local/zeebe/server.pem
+      - ZEEBE_BROKER_GATEWAY_SECURITY_CERTIFICATECHAINPATH=/usr/local/zeebe/server.cert.pem
+      - ZEEBE_BROKER_GATEWAY_SECURITY_PRIVATEKEYPATH=/usr/local/zeebe/server.key.pem
       - ZEEBE_BROKER_GATEWAY_NETWORK_PORT=${ZEEBE_PORT:-26500}
     volumes:
       - ./application.yaml:/usr/local/zeebe/config/application.yaml
-      - ./cert/server.crt:/usr/local/zeebe/server.crt
-      - ./cert/server.pem:/usr/local/zeebe/server.pem
+      - ./cert/server.cert.pem:/usr/local/zeebe/server.cert.pem
+      - ./cert/server.key.pem:/usr/local/zeebe/server.key.pem
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://0.0.0.0:9600/actuator/health" ]
       interval: 5s
@@ -39,8 +39,8 @@ services:
       - PROXY_PORT=${PROXY_PORT:-443}
     volumes:
       - ./nginx/templates:/etc/nginx/templates
-      - ./cert/server.crt:/usr/local/proxy/server.pem
-      - ./cert/server.pem:/usr/local/proxy/server.crt
+      - ./cert/server.cert.pem:/usr/local/proxy/server.cert.pem
+      - ./cert/server.key.pem:/usr/local/proxy/server.key.pem
     ports:
       - "${PROXY_PORT:-443}:${PROXY_PORT:-443}"
     networks:
@@ -55,10 +55,10 @@ services:
     environment:
       - ZEEBE_ADDRESS=${ZEEBE_HOSTNAME:-sub.example.com}:${ZEEBE_PORT:-26500}
       - ZEEBE_INSECURE_CONNECTION=${ZEEBE_INSECURE_CONNECTION:-false}
-      - ZEEBE_CA_CERTIFICATE_PATH=/usr/local/zeebe/root.crt
+      - ZEEBE_CA_CERTIFICATE_PATH=/usr/local/zeebe/root.cert.pem
     command: sh -c "ping ${ZEEBE_HOSTNAME:-sub.example.com} -c 1 && npx zbctl status -o json"
     volumes:
-      - ./cert/root.crt:/usr/local/zeebe/root.crt
+      - ./cert/root.cert.pem:/usr/local/zeebe/root.cert.pem
     networks:
       - test
   zebee-node-test:
@@ -71,13 +71,13 @@ services:
     environment:
       - ZEEBE_ADDRESS=${ZEEBE_HOSTNAME:-sub.example.com}:${ZEEBE_PORT:-26500}
       - ZEEBE_INSECURE_CONNECTION=${ZEEBE_INSECURE_CONNECTION:-false}
-      - ZEEBE_CA_CERTIFICATE_PATH=/usr/local/zeebe/root.crt
+      - ZEEBE_CA_CERTIFICATE_PATH=/usr/local/zeebe/root.cert.pem
       - LOG_LEVEL=debug
       - GRPC_VERBOSITY=DEBUG
       - GRPC_TRACE=channel,subchannel,call_stream
     command: sh -c "ping ${ZEEBE_HOSTNAME:-sub.example.com} -c 1 && cd /usr/local/zeebe && node index.js"
     volumes:
-      - ./cert/root.crt:/usr/local/zeebe/root.crt
+      - ./cert/root.cert.pem:/usr/local/zeebe/root.cert.pem
       - ./index.js:/usr/local/zeebe/index.js
       - ./node_modules:/usr/local/zeebe/node_modules
     networks:
@@ -92,13 +92,13 @@ services:
     environment:
       - ZEEBE_ADDRESS=${ZEEBE_HOSTNAME:-sub.example.com}:${ZEEBE_PORT:-26500}
       - ZEEBE_INSECURE_CONNECTION=${ZEEBE_INSECURE_CONNECTION:-false}
-      - ZEEBE_CA_CERTIFICATE_PATH=/usr/local/zeebe/root.crt
+      - ZEEBE_CA_CERTIFICATE_PATH=/usr/local/zeebe/root.cert.pem
       - LOG_LEVEL=debug
       - GRPC_VERBOSITY=DEBUG
       - GRPC_TRACE=channel,subchannel,call_stream
     command: sh -c "ping ${ZEEBE_HOSTNAME:-sub.example.com} -c 1 && cd /usr/local/zeebe && node camunda-sdk.js"
     volumes:
-      - ./cert/root.crt:/usr/local/zeebe/root.crt
+      - ./cert/root.cert.pem:/usr/local/zeebe/root.cert.pem
       - ./camunda-sdk.js:/usr/local/zeebe/camunda-sdk.js
       - ./node_modules:/usr/local/zeebe/node_modules
     networks:

--- a/nginx/templates/proxy.conf.template
+++ b/nginx/templates/proxy.conf.template
@@ -2,8 +2,8 @@ server {
   listen ${PROXY_PORT} ssl;
   http2 on;
 
-  ssl_certificate /usr/local/proxy/server.cert.pem;
   ssl_certificate_key /usr/local/proxy/server.key.pem;
+  ssl_certificate /usr/local/proxy/${PROXY_SERVER_CERTIFICATE};
 
   location / {
     grpc_pass grpc://${ZEEBE_HOSTNAME}:${ZEEBE_PORT};

--- a/nginx/templates/proxy.conf.template
+++ b/nginx/templates/proxy.conf.template
@@ -2,8 +2,8 @@ server {
   listen ${PROXY_PORT} ssl;
   http2 on;
 
-  ssl_certificate /usr/local/proxy/server.pem;
-  ssl_certificate_key /usr/local/proxy/server.crt;
+  ssl_certificate /usr/local/proxy/server.cert.pem;
+  ssl_certificate_key /usr/local/proxy/server.key.pem;
 
   location / {
     grpc_pass grpc://${ZEEBE_HOSTNAME}:${ZEEBE_PORT};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "npm run test:insecure && npm run test:secure",
     "test:insecure": "ZEEBE_INSECURE_CONNECTION=true npm run test:clients",
-    "test:secure": "ZEEBE_INSECURE_CONNECTION=false ZEEBE_CA_CERTIFICATE_PATH=./cert/root.cert.pem npm run test:clients",
+    "test:secure": "ZEEBE_INSECURE_CONNECTION=false ZEEBE_CA_CERTIFICATE_PATH=./cert/ca-chain.cert.pem npm run test:clients",
     "test:clients": "npm run test:zeebe-node && npm run test:zbctl && npm run test:camunda-sdk",
     "test:zbctl": "zbctl status -o json",
     "test:zeebe-node": "LOG_LEVEL=debug GRPC_VERBOSITY=DEBUG GRPC_TRACE=channel,subchannel,call_stream node index.js",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "npm run test:insecure && npm run test:secure",
     "test:insecure": "ZEEBE_INSECURE_CONNECTION=true npm run test:clients",
-    "test:secure": "ZEEBE_INSECURE_CONNECTION=false ZEEBE_CA_CERTIFICATE_PATH=./cert/root.crt npm run test:clients",
+    "test:secure": "ZEEBE_INSECURE_CONNECTION=false ZEEBE_CA_CERTIFICATE_PATH=./cert/root.cert.pem npm run test:clients",
     "test:clients": "npm run test:zeebe-node && npm run test:zbctl && npm run test:camunda-sdk",
     "test:zbctl": "zbctl status -o json",
     "test:zeebe-node": "LOG_LEVEL=debug GRPC_VERBOSITY=DEBUG GRPC_TRACE=channel,subchannel,call_stream node index.js",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "npm run test:insecure && npm run test:secure",
     "test:insecure": "ZEEBE_INSECURE_CONNECTION=true npm run test:clients",
-    "test:secure": "ZEEBE_INSECURE_CONNECTION=false ZEEBE_CA_CERTIFICATE_PATH=./cert/ca-chain.cert.pem npm run test:clients",
+    "test:secure": "ZEEBE_INSECURE_CONNECTION=false ZEEBE_CA_CERTIFICATE_PATH=\"./cert/${CA_CERTIFICATE:-ca-chain.cert.pem}\" npm run test:clients",
     "test:clients": "npm run test:zeebe-node && npm run test:zbctl && npm run test:camunda-sdk",
     "test:zbctl": "zbctl status -o json",
     "test:zeebe-node": "LOG_LEVEL=debug GRPC_VERBOSITY=DEBUG GRPC_TRACE=channel,subchannel,call_stream node index.js",


### PR DESCRIPTION
This ensures we support the typical intermediate CA setup (https://github.com/camunda/zeebe-connection-test/pull/15/commits/98dade55a5fb3337bd729733902051134bc33d67).

At the same time, it documents fullchain serving from proxy servers (typical, too) (https://github.com/camunda/zeebe-connection-test/pull/15/commits/cee600a18903dcb6943ae4d21437a5b9df032c43) and disables the health check, which is broken due to [missing `curl` in bundle](https://camunda.slack.com/archives/CSQ2E3BT4/p1741344109070539) (https://github.com/camunda/zeebe-connection-test/pull/15/commits/e9e35e56c0c061e8ee42ffe1cbdf3ddc3c9df5af).